### PR TITLE
Use generic params

### DIFF
--- a/lib/orthoses/paranoia.rb
+++ b/lib/orthoses/paranoia.rb
@@ -17,18 +17,15 @@ module Orthoses
 
       acts_as_paranoid.captures.each do |capture|
         base_name = Utils.module_name(capture.method.receiver) or next
-        paranoia_class_methods = "#{base_name}::ParanoiaMethods"
-        next if store.key?(paranoia_class_methods)
+        relation_class = "#{base_name}::ActiveRecord_Relation"
+        paranoia_instance_methods = "::Paranoia::InstanceMethods[#{base_name}]"
+        paranoia_class_methods = "::Paranoia::ClassMethods[#{base_name}, #{relation_class}]"
 
-        store[paranoia_class_methods].header = "module #{paranoia_class_methods}"
-        store[paranoia_class_methods] << "def with_deleted: () -> #{base_name}::ActiveRecord_Relation"
-        store[paranoia_class_methods] << "def only_deleted: () -> #{base_name}::ActiveRecord_Relation"
-        store[paranoia_class_methods] << "alias deleted only_deleted"
-        store[paranoia_class_methods] << "def paranoia_scope: () -> #{base_name}::ActiveRecord_Relation"
-        store[paranoia_class_methods] << "alias without_deleted paranoia_scope"
-
+        store[base_name] << "include #{paranoia_instance_methods}"
         store[base_name] << "extend #{paranoia_class_methods}"
-        store["#{base_name}::ActiveRecord_Relation"] << "include #{paranoia_class_methods}"
+
+        store[relation_class] << "include #{paranoia_class_methods}"
+
         store["#{base_name}::ActiveRecord_Associations_CollectionProxy"] << "include #{paranoia_class_methods}"
       end
 

--- a/lib/orthoses/paranoia_test.rb
+++ b/lib/orthoses/paranoia_test.rb
@@ -20,7 +20,8 @@ module ParanoiaTest
     actual = store["ParanoiaTest::User"].to_rbs
     expect = <<~RBS
       class ParanoiaTest::User < ::ActiveRecord::Base
-        extend ParanoiaTest::User::ParanoiaMethods
+        include ::Paranoia::InstanceMethods[ParanoiaTest::User]
+        extend ::Paranoia::ClassMethods[ParanoiaTest::User, ParanoiaTest::User::ActiveRecord_Relation]
       end
     RBS
     unless expect == actual
@@ -30,7 +31,7 @@ module ParanoiaTest
     actual = store["ParanoiaTest::User::ActiveRecord_Relation"].to_rbs
     expect = <<~RBS
       class ParanoiaTest::User::ActiveRecord_Relation < ::ActiveRecord::Relation
-        include ParanoiaTest::User::ParanoiaMethods
+        include ::Paranoia::ClassMethods[ParanoiaTest::User, ParanoiaTest::User::ActiveRecord_Relation]
       end
     RBS
     unless expect == actual
@@ -40,7 +41,7 @@ module ParanoiaTest
     actual = store["ParanoiaTest::User::ActiveRecord_Associations_CollectionProxy"].to_rbs
     expect = <<~RBS
       class ParanoiaTest::User::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-        include ParanoiaTest::User::ParanoiaMethods
+        include ::Paranoia::ClassMethods[ParanoiaTest::User, ParanoiaTest::User::ActiveRecord_Relation]
       end
     RBS
     unless expect == actual
@@ -50,24 +51,6 @@ module ParanoiaTest
     actual = store["ParanoiaTest::Post"].to_rbs
     expect = <<~RBS
       class ParanoiaTest::Post < ::ActiveRecord::Base
-      end
-    RBS
-    unless expect == actual
-      t.error("expect=\n```rbs\n#{expect}```\n, but got \n```rbs\n#{actual}```\n")
-    end
-
-    actual = store["ParanoiaTest::User::ParanoiaMethods"].to_rbs
-    expect = <<~RBS
-      module ParanoiaTest::User::ParanoiaMethods
-        def with_deleted: () -> ParanoiaTest::User::ActiveRecord_Relation
-
-        def only_deleted: () -> ParanoiaTest::User::ActiveRecord_Relation
-
-        alias deleted only_deleted
-
-        def paranoia_scope: () -> ParanoiaTest::User::ActiveRecord_Relation
-
-        alias without_deleted paranoia_scope
       end
     RBS
     unless expect == actual


### PR DESCRIPTION
I have adopted the module introduced in https://github.com/ruby/gem_rbs_collection/pull/861.
This change enables the use of instance method types and improves maintainability.